### PR TITLE
objectコレクションのperseptualHash要素をimage要素内に移動

### DIFF
--- a/ocaz-sandbox/src/ocaz_sandbox/migration/move_phash_to_image.py
+++ b/ocaz-sandbox/src/ocaz_sandbox/migration/move_phash_to_image.py
@@ -19,20 +19,16 @@ def move_phash_to_image(
         mongodb[COLLECTION_OBJECT]
         .find({"image": {"$exists": True}, "perseptualHash": {"$exists": True}})
         .sort("_id", pymongo.ASCENDING)
-        .limit(1)
+        .limit(10000)
     )
 
     for record in records:
         print(record)
-
-        new_image = dict(record["image"])
-        new_image["perseptualHash"] = record["perseptualHash"]
-
         mongodb[COLLECTION_OBJECT].update_one(
             {"_id": record["_id"]},
             {
                 "$set": {
-                    "image": new_image,
+                    "image.perseptualHash": record["perseptualHash"],
                 },
                 "$unset": {
                     "perseptualHash": 1,

--- a/ocaz-sandbox/src/ocaz_sandbox/migration/move_phash_to_image.py
+++ b/ocaz-sandbox/src/ocaz_sandbox/migration/move_phash_to_image.py
@@ -1,0 +1,58 @@
+import json
+import logging
+
+import click
+import pymongo
+
+from ..command import option_log_level, option_mongodb_url
+from ..db import get_database
+
+COLLECTION_OBJECT = "object"
+
+
+def move_phash_to_image(
+    mongodb_url: str,
+) -> None:
+    mongodb = get_database(mongodb_url)
+
+    records = (
+        mongodb[COLLECTION_OBJECT]
+        .find({"image": {"$exists": True}, "perseptualHash": {"$exists": True}})
+        .sort("_id", pymongo.ASCENDING)
+        .limit(1)
+    )
+    records = list(records)
+    for record in records:
+        print(record)
+
+        new_image = dict(record["image"])
+        new_image["perseptualHash"] = record["perseptualHash"]
+        print(new_image)
+
+        mongodb[COLLECTION_OBJECT].update_one(
+            {"_id": record["_id"]},
+            {
+                "$set": {
+                    "image": new_image,
+                },
+            },
+        )
+
+
+@click.command()
+@option_log_level
+@option_mongodb_url
+def main(log_level: str, mongodb_url: str) -> None:
+    logging.basicConfig(
+        format="%(asctime)s %(levelname)s pid:%(process)d %(message)s",
+        level=getattr(logging, log_level.upper(), logging.INFO),
+    )
+    logging.debug(f"log_level = {json.dumps(log_level)}")
+
+    move_phash_to_image(mongodb_url=mongodb_url)
+
+    logging.info("done")
+
+
+if __name__ == "__main__":
+    main()

--- a/ocaz-sandbox/src/ocaz_sandbox/migration/move_phash_to_image.py
+++ b/ocaz-sandbox/src/ocaz_sandbox/migration/move_phash_to_image.py
@@ -21,19 +21,21 @@ def move_phash_to_image(
         .sort("_id", pymongo.ASCENDING)
         .limit(1)
     )
-    records = list(records)
+
     for record in records:
         print(record)
 
         new_image = dict(record["image"])
         new_image["perseptualHash"] = record["perseptualHash"]
-        print(new_image)
 
         mongodb[COLLECTION_OBJECT].update_one(
             {"_id": record["_id"]},
             {
                 "$set": {
                     "image": new_image,
+                },
+                "$unset": {
+                    "perseptualHash": 1,
                 },
             },
         )

--- a/ocaz-sandbox/src/ocaz_sandbox/resolve_phash.py
+++ b/ocaz-sandbox/src/ocaz_sandbox/resolve_phash.py
@@ -24,7 +24,7 @@ def find_phash_unresolved_object_ids(
 ) -> List[Any]:
     records = (
         mongodb[COLLECTION_OBJECT]
-        .find({"image": {"$exists": True}, "perseptualHash": {"$exists": False}}, {"_id": True})
+        .find({"image": {"$exists": True}, "image.perseptualHash": {"$exists": False}}, {"_id": True})
         .sort("_id", pymongo.ASCENDING)
     )
     if max_records:
@@ -87,7 +87,7 @@ def resolve_objects(mongodb_url: str, object_ids: List[str]) -> None:
             pymongo.UpdateOne(
                 {"_id": object_id},
                 {
-                    "$set": {"perseptualHash": phash},
+                    "$set": {"image.perseptualHash": phash},
                 },
             )
         )

--- a/ocaz-sandbox/src/ocaz_sandbox/stats.py
+++ b/ocaz-sandbox/src/ocaz_sandbox/stats.py
@@ -27,8 +27,8 @@ def stats(mongodb_url: str) -> None:
     logging.info(f"object = {count_object({})}")
     logging.info(f'object.sha1 = {count_object({"sha1": {"$exists": True}})}')
     logging.info(f'object.image = {count_object({"image": {"$exists": True}})}')
+    logging.info(f'object.image.perseptualHash = {count_object({"image.perseptualHash": {"$exists": True}})}')
     logging.info(f'object.video = {count_object({"video": {"$exists": True}})}')
-    logging.info(f'object.perseptualHash = {count_object({"perseptualHash": {"$exists": True}})}')
 
 
 @click.command()


### PR DESCRIPTION
# 概要

`object`コレクションの`perseptualHash`要素を`image`要素内に移動しました。
また、データ移行用の`ocaz_sandbox.migration.move_phash_to_image`コマンドを追加しました。

# 関連

* #20
